### PR TITLE
Generate version with commitId

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,17 @@
-# Editor configuration, see http://editorconfig.org
+# Version: 1.5.0 (Using https://semver.org/)
+# Updated: 2020-03-09
+# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
+# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# See http://EditorConfig.org for more information about .editorconfig files.
+
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
 root = true
 
+# All Files
 [*]
 charset = utf-8
 indent_style = space
@@ -10,20 +21,41 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 80
 
+##########################################
+# File Extension Settings
+##########################################
+
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown Files
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false
 
-[*.yml]
-indent_size = 4
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,svg,vue}]
+indent_size = 2
 
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Bash Files
 [*.sh]
 end_of_line = lf
 
+# Java Files
 [*.java]
 indent_size = 4
 max_line_length = 120
 continuation_indent_size = 8
-
-[*.xml]
-indent_size = 4

--- a/.github/workflows/maven-java.yml
+++ b/.github/workflows/maven-java.yml
@@ -18,6 +18,22 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
         run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
 
   maven-build-test-package-deploy-site:
     name: Maven test, package and deploy Java project
@@ -34,7 +50,7 @@ jobs:
           SERVER_PASSWORD: ${{ secrets.MVN_PCKGS_REPO_TOKEN}}
       - name: Check out from version control
         uses: actions/checkout@v2
-      - name: Cache Maven packages
+      - name: Cache Maven dependencies
         uses: actions/cache@v1
         env:
           cache-name: cache-maven-dependencies
@@ -45,38 +61,33 @@ jobs:
             ${{ runner.os }}-m2-${{ env.cache-name }}-
             ${{ runner.os }}-m2-
             ${{ runner.os }}-
-      - name: Get groupId
-        run: mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate '-Dexpression=project.groupId' -q -DforceStdout --file pom.xml --settings .github/workflows/settings.xml
+      - name: Get Maven Project information
+        id: maven-project-info
+        run: |
+          echo "$(mvn help:evaluate -Dexpression=project.groupId -q -DforceStdout --file pom.xml --settings .github/workflows/settings.xml)"
+          echo "$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout --file pom.xml --settings .github/workflows/settings.xml)"
+          echo "::set-output name=VERSION::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --file pom.xml --settings .github/workflows/settings.xml)"
+          echo "::set-output name=PACKAGING::$(mvn help:evaluate -Dexpression=project.packaging -q -DforceStdout --file pom.xml --settings .github/workflows/settings.xml)"
         env:
           SERVER_USERNAME: $GITHUB_ACTOR
           SERVER_PASSWORD: ${{ secrets.MVN_PCKGS_REPO_TOKEN}}
-      - name: Get artifactId
-        run: mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate '-Dexpression=project.artifactId' -q -DforceStdout --file pom.xml --settings .github/workflows/settings.xml
-        env:
-          SERVER_USERNAME: $GITHUB_ACTOR
-          SERVER_PASSWORD: ${{ secrets.MVN_PCKGS_REPO_TOKEN}}
-      - name: Get version
-        id: build-version-initial
-        run: mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate '-Dexpression=project.version' -q -DforceStdout --file pom.xml --settings .github/workflows/settings.xml
-        env:
-          SERVER_USERNAME: $GITHUB_ACTOR
-          SERVER_PASSWORD: ${{ secrets.MVN_PCKGS_REPO_TOKEN}}
-      #TODEL - name: Get short SHA
-      #TODEL   id: short-sha
-      #TODEL   run: |
-      #TODEL     echo "Version initiale: ${MVN_VERSION}"
-      #TODEL     echo "::set-env name=COMMIT_ID_SHORT::${GITHUB_SHA::8}"
-      #TODEL - name: Create version number
-      #TODEL   id: create-version-number
-      #TODEL   uses: frabert/replace-string-action@v1.1
-      #TODEL   with:
-      #TODEL     pattern: "^(.*)-SNAPSHOT$"
-      #TODEL     string: ${{env.MVN_VERSION}}
-      #TODEL     replace-with: "$1-${COMMIT_ID_SHORT}-SNAPSHOT"
-      #TODEL - name: Set version number
-      #TODEL   run: |
-      #TODEL     echo "New version: ${{ steps.create-version-number.outputs.replaced }}"
-      #TODEL     mvn versions:set -DnewVersion=${{ steps.create-version-number.outputs.replaced }}
+      - name: Get short SHA
+        id: short-sha
+        run: |
+          echo "Maven Project version: ${{ steps.maven-project-info.outputs.VERSION }}"
+          echo "::set-output name=COMMIT_ID_SHORT::${GITHUB_SHA::8}"
+      - name: Create version number
+        id: create-version-number
+        uses: frabert/replace-string-action@v1.1
+        with:
+          pattern: "^(.*)-SNAPSHOT$"
+          string: ${{ steps.maven-project-info.outputs.VERSION }}
+          replace-with: "$1-${{ steps.short-sha.outputs.COMMIT_ID_SHORT }}-SNAPSHOT"
+      - name: Set version number
+        if: endsWith( steps.maven-project-info.outputs.VERSION, '-SNAPSHOT' ) && ( steps.maven-project-info.outputs.PACKAGING != 'pom' )
+        run: |
+          echo "New version: ${{ steps.create-version-number.outputs.replaced }}"
+          mvn versions:set -DnewVersion=${{ steps.create-version-number.outputs.replaced }} --file pom.xml
       - name: Build with Maven
         run: mvn -U clean compile -Pproject-controls-check --file pom.xml --settings .github/workflows/settings.xml
         env:

--- a/.github/workflows/settings.xml
+++ b/.github/workflows/settings.xml
@@ -1,51 +1,51 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <activeProfiles>
-        <activeProfile>github</activeProfile>
-    </activeProfiles>
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
 
-    <profiles>
-        <profile>
-            <id>github</id>
-            <repositories>
-                <repository>
-                    <id>central</id>
-                    <url>https://repo1.maven.org/maven2</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>always</updatePolicy>
-                    </snapshots>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                    </releases>
-                </repository>
-                <repository>
-                    <id>github</id>
-                    <name>GitHub Release bdelion/maven-packages Apache Maven Packages</name>
-                    <url>https://maven.pkg.github.com/bdelion/maven-packages</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>always</updatePolicy>
-                    </snapshots>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                    </releases>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>daily</updatePolicy>
+          </releases>
+        </repository>
+        <repository>
+          <id>github</id>
+          <name>GitHub Release bdelion/maven-packages Apache Maven Packages</name>
+          <url>https://maven.pkg.github.com/bdelion/maven-packages</url>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>daily</updatePolicy>
+          </releases>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 
-    <servers>
-        <server>
-            <id>github</id>
-            <username>${env.SERVER_USERNAME}</username>
-            <password>${env.SERVER_PASSWORD}</password>
-        </server>
-    </servers>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+  </servers>
 
-    <pluginGroups></pluginGroups>
-    <proxies></proxies>
-    <mirrors></mirrors>
+  <pluginGroups></pluginGroups>
+  <proxies></proxies>
+  <mirrors></mirrors>
 </settings>

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Pour exécuter localement `simple-java8-validator`, il faut :
 
 ## :construction_worker: Fabriqué avec
 
-* [Visual Studio Code] - Editeur de code source.
-* [Maven] - Outil de gestion et d'automatisation de production des projets logiciels.
-* [Travis CI] - Logiciel libre d'intégration continue.
+-   [Visual Studio Code] - Editeur de code source.
+-   [Maven] - Outil de gestion et d'automatisation de production des projets logiciels.
+-   [Travis CI] - Logiciel libre d'intégration continue.
 
 ## :busts_in_silhouette: Authors
 
 :bust_in_silhouette: **Bertrand DELION**
 
-* Github: [@bdelion]
+-   Github: [@bdelion]
 
 Voir aussi la liste des [contributeurs] ayant participés à ce projet.
 
@@ -64,33 +64,32 @@ Pour les versions disponibles, voir [les tags de ce projet].
 
 ## :link: Liens utiles
 
-* :pencil: Documentation : [Wiki]
-* :building_construction: Build :
-  * [Job Travis CI]
-  * [Github Actions]
-* Repository : [GitHub Package Registry]
+-   :pencil: Documentation : [Wiki]
+-   :building_construction: Build :
+    -   [Job Travis CI]
+    -   [Github Actions]
+-   Repository : [GitHub Package Registry]
 
 ## :spider_web: Dependency
 
-* [Dependencies] - Dépendances de ce projet
-* [Dependents] - Projets dépendants de celui-ci
+-   [Dependencies] - Dépendances de ce projet
+-   [Dependents] - Projets dépendants de celui-ci
 
-
-[Make a README]: https://www.makeareadme.com/#template-1
-[Homepage]: https://github.com/bdelion/simple-java8-validator/tree/master
+[make a readme]: https://www.makeareadme.com/#template-1
+[homepage]: https://github.com/bdelion/simple-java8-validator/tree/master
 [simple-java8-validator-1.0.0-jar-with-dependencies.jar]: https://github.com/bdelion/maven-packages/packages/183594?version=1.0.0
-[Visual Studio Code]: https://code.visualstudio.com/
-[Maven]: https://maven.apache.org/
-[Travis CI]: https://travis-ci.com/
+[visual studio code]: https://code.visualstudio.com/
+[maven]: https://maven.apache.org/
+[travis ci]: https://travis-ci.com/
 [@bdelion]: https://github.com/bdelion
 [contributeurs]: https://github.com/bdelion/simple-java8-validator/graphs/contributors
-[CHANGELOG]: CHANGELOG.md
+[changelog]: CHANGELOG.md
 [issues]: https://github.com/bdelion/simple-java8-validator/issues
-[SemVer]: http://semver.org/
+[semver]: http://semver.org/
 [les tags de ce projet]: https://github.com/bdelion/simple-java8-validator/tags
-[Wiki]: https://github.com/bdelion/simple-java8-validator/wiki
-[Job Travis CI]: https://travis-ci.com/bdelion/simple-java8-validator
-[Github Actions]: https://github.com/bdelion/simple-java8-validator/actions
-[GitHub Package Registry]: https://github.com/bdelion/simple-java8-validator/packages
-[Dependencies]: https://github.com/bdelion/simple-java8-validator/network/dependencies
-[Dependents]: https://github.com/bdelion/simple-java8-validator/network/dependents
+[wiki]: https://github.com/bdelion/simple-java8-validator/wiki
+[job travis ci]: https://travis-ci.com/bdelion/simple-java8-validator
+[github actions]: https://github.com/bdelion/simple-java8-validator/actions
+[github package registry]: https://github.com/bdelion/simple-java8-validator/packages
+[dependencies]: https://github.com/bdelion/simple-java8-validator/network/dependencies
+[dependents]: https://github.com/bdelion/simple-java8-validator/network/dependents

--- a/pom.xml
+++ b/pom.xml
@@ -1,96 +1,96 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <!-- Version du fichier -->
-    <modelVersion>4.0.0</modelVersion>
+  <!-- Version du fichier -->
+  <modelVersion>4.0.0</modelVersion>
 
-    <!-- Pom parent -->
-    <parent>
-        <groupId>fr.fifiz.socle.java</groupId>
-        <artifactId>java-parent</artifactId>
-        <version>8.0.0-SNAPSHOT</version>
-    </parent>
-    <!-- Definition de l'artefact -->
-    <groupId>fr.fifiz.training.app.java</groupId>
-    <artifactId>simple-java8-validator</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    <name>FIFIZ :: Java App :: simple-java8-validator</name>
-    <description>Application quickstart permettant de valider les évolutions du pom parent `fr.fifiz.socle.java:java-parent`</description>
+  <!-- Pom parent -->
+  <parent>
+    <groupId>fr.fifiz.socle.java</groupId>
+    <artifactId>java-parent</artifactId>
+    <version>8.0.0-SNAPSHOT</version>
+  </parent>
+  <!-- Definition de l'artefact -->
+  <groupId>fr.fifiz.training.app.java</groupId>
+  <artifactId>simple-java8-validator</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>FIFIZ :: Java App :: simple-java8-validator</name>
+  <description>Application quickstart permettant de valider les évolutions du pom parent `fr.fifiz.socle.java:java-parent`</description>
 
-    <!-- FIXME change it to the project's website -->
-    <url>https://bdelion.github.io/simple-java8-validator/</url>
-    <!-- FIXME add licences -->
+  <!-- FIXME change it to the project's website -->
+  <url>https://bdelion.github.io/simple-java8-validator/</url>
+  <!-- FIXME add licences -->
 
-    <organization>
-        <name>FIFIZ Company</name>
-        <url>https://bdelion.github.io/</url>
-    </organization>
+  <organization>
+    <name>FIFIZ Company</name>
+    <url>https://bdelion.github.io/</url>
+  </organization>
 
-    <developers>
-        <developer>
-            <id>bdelion</id>
-            <name>Bertrand Delion</name>
-            <email>bertrand.delion@free.fr</email>
-            <url>https://github.com/bdelion</url>
-            <organization>FIFIZ Company</organization>
-            <organizationUrl>https://github.com/bdelion</organizationUrl>
-            <timezone>+1</timezone>
-            <roles>
-                <role>Architect</role>
-                <role>Developer</role>
-            </roles>
-        </developer>
-    </developers>
+  <developers>
+    <developer>
+      <id>bdelion</id>
+      <name>Bertrand Delion</name>
+      <email>bertrand.delion@free.fr</email>
+      <url>https://github.com/bdelion</url>
+      <organization>FIFIZ Company</organization>
+      <organizationUrl>https://github.com/bdelion</organizationUrl>
+      <timezone>+1</timezone>
+      <roles>
+        <role>Architect</role>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
 
-    <!-- Gestionnaire de code source -->
-    <!-- https://github.com/kevinsawicki/github-maven-example/blob/master/example/pom.xml -->
-    <scm>
-        <url>https://github.com/bdelion/simple-java8-validator.git</url>
-        <connection>scm:git:git://github.com:bdelion/simple-java8-validator.git</connection>
-        <developerConnection>scm:git:git@github.com:bdelion/simple-java8-validator.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-    <issueManagement>
-        <url>https://github.com/bdelion/simple-java8-validator/issues</url>
-        <system>GitHub Issues</system>
-    </issueManagement>
-    <ciManagement>
-        <system>GitHub Actions</system>
-        <url>https://github.com/bdelion/simple-java8-validator/actions</url>
-    </ciManagement>
+  <!-- Gestionnaire de code source -->
+  <!-- https://github.com/kevinsawicki/github-maven-example/blob/master/example/pom.xml -->
+  <scm>
+    <url>https://github.com/bdelion/simple-java8-validator.git</url>
+    <connection>scm:git:git://github.com:bdelion/simple-java8-validator.git</connection>
+    <developerConnection>scm:git:git@github.com:bdelion/simple-java8-validator.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/bdelion/simple-java8-validator/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+  <ciManagement>
+    <system>GitHub Actions</system>
+    <url>https://github.com/bdelion/simple-java8-validator/actions</url>
+  </ciManagement>
 
-    <!-- Repositories nécessaire pour avoir accès aux packages GitHub -->
-    <repositories>
-        <repository>
-            <id>github</id>
-            <name>GitHub bdelion/maven-packages Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/bdelion/maven-packages</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
+  <!-- Repositories nécessaire pour avoir accès aux packages GitHub -->
+  <repositories>
+    <repository>
+      <id>github</id>
+      <name>GitHub bdelion/maven-packages Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/bdelion/maven-packages</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
-    <properties>
-        <!-- Assembly -->
-        <maven-assembly-plugin-skip>false</maven-assembly-plugin-skip>
-        <main-class>fr.fifiz.socle.java.SimpleJava8ValidatorApp</main-class>
-    </properties>
+  <properties>
+    <!-- Assembly -->
+    <maven-assembly-plugin-skip>false</maven-assembly-plugin-skip>
+    <main-class>fr.fifiz.socle.java.SimpleJava8ValidatorApp</main-class>
+  </properties>
 
-    <dependencies>
-        <!-- Pour les tests -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <!-- Pour les tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
Pour project Maven qui ont un packaging différent de `pom` et une version contenant `-SNAPSHOT`, on ajoute le commitId dans la version afin de pouvoir publier dans GitHub Packages.